### PR TITLE
Update dependency info for the puppetlabs-concat module

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
         },
         {
             "name": "puppetlabs/stdlib",
-            "version_requirement": ">= 3.2.0 < 6.0.0"
+            "version_requirement": ">= 3.2.0 <= 6.2.0"
         }
     ]
 }


### PR DESCRIPTION
This fixes the warnings shown on the puppet master such as follows.

Warning: Module 'puppetlabs-concat' (v6.2.0) fails to meet some dependencies:
  'doubledog-koji_helpers' (v2.0.0) requires 'puppetlabs-concat' (>= 4.0.0 < 6.0.0)